### PR TITLE
1.0.1

### DIFF
--- a/src/Expressions/Contains.php
+++ b/src/Expressions/Contains.php
@@ -30,6 +30,10 @@ trait Contains
      */
     public function doesntContain(string|int $chars): self
     {
+        if (is_string($chars) && $chars === '') {
+            return $this;
+        }
+
         return $this->addPattern('(?!.*' . preg_quote((string) $chars, '/') . ')', false);
     }
 
@@ -63,7 +67,11 @@ trait Contains
      */
     public function doesntContainAnyOf(string|array $chars): self
     {
-        if (empty($chars)) {
+        if (is_array($chars) && $chars === []) {
+            return $this;
+        }
+
+        if (is_string($chars) && $chars === '') {
             return $this;
         }
 
@@ -89,7 +97,7 @@ trait Contains
      */
     public function doesntContainDigit(): self
     {
-        return $this->addPattern('^(?!.*\d).+$', false);
+        return $this->addPattern('^(?!.*\d).*$', false);
     }
 
     /**
@@ -119,7 +127,11 @@ trait Contains
      */
     public function doesntContainBetween(array $ranges, bool $caseSensitive = true): self
     {
-        return $this->addPattern('^(?!.*' . new RangePattern($ranges, negated: false, caseSensitive: $caseSensitive) . ').+$', false);
+        if ($ranges === []) {
+            return $this;
+        }
+
+        return $this->addPattern('^(?!.*' . new RangePattern($ranges, negated: false, caseSensitive: $caseSensitive) . ').*$', false);
     }
 
     /**
@@ -127,7 +139,7 @@ trait Contains
      */
     public function doesntContainOnlyDigits(): self
     {
-        return $this->addPattern("^(?!\d+$).+");
+        return $this->addPattern("^$|^(?!\d+$).+");
     }
 
     /**
@@ -167,7 +179,7 @@ trait Contains
      */
     public function doesntContainOnlyAlphaNumeric(): self
     {
-        return $this->addPattern("[^A-Za-z0-9]");
+        return $this->addPattern("^$|[^A-Za-z0-9]");
     }
 
     /**

--- a/src/Expressions/Contains.php
+++ b/src/Expressions/Contains.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DamilareKoiki\PhpRegex\Expressions;
 
 use DamilareKoiki\PhpRegex\Resolvers\RangePattern;
+use InvalidArgumentException;
 
 use function is_array;
 use function is_string;
@@ -30,10 +31,6 @@ trait Contains
      */
     public function doesntContain(string|int $chars): self
     {
-        if (is_string($chars) && $chars === '') {
-            return $this;
-        }
-
         return $this->addPattern('(?!.*' . preg_quote((string) $chars, '/') . ')', false);
     }
 
@@ -44,8 +41,12 @@ trait Contains
      */
     public function containsAnyOf(string|array $chars): self
     {
-        if (empty($chars)) {
-            return $this;
+        if (is_array($chars) && $chars === []) {
+            throw new InvalidArgumentException('Chars cannot be an empty array. Pass an empty string instead or wrap the method around the when() method.');
+        }
+
+        if (is_string($chars) && $chars === '') {
+            return $this->addPattern('(?=.*)', false);
         }
 
         if (is_array($chars)) {
@@ -68,11 +69,11 @@ trait Contains
     public function doesntContainAnyOf(string|array $chars): self
     {
         if (is_array($chars) && $chars === []) {
-            return $this;
+            throw new InvalidArgumentException('Chars cannot be an empty array. Pass an empty string instead or wrap the method around the when() method.');
         }
 
         if (is_string($chars) && $chars === '') {
-            return $this;
+            return $this->addPattern('(?!)', false);
         }
 
         if (is_array($chars)) {
@@ -116,6 +117,10 @@ trait Contains
      */
     public function containsBetween(array $ranges, bool $caseSensitive = true): self
     {
+        if ($ranges === []) {
+            throw new InvalidArgumentException('Ranges cannot be empty. Wrap the method around the when() method to prevent this error.');
+        }
+
         return $this->addPattern('(?=.*' . new RangePattern($ranges, negated: false, caseSensitive: $caseSensitive) . ')', false);
     }
 
@@ -128,7 +133,7 @@ trait Contains
     public function doesntContainBetween(array $ranges, bool $caseSensitive = true): self
     {
         if ($ranges === []) {
-            return $this;
+            throw new InvalidArgumentException('Ranges cannot be empty. Wrap the method around the when() method to prevent this error.');
         }
 
         return $this->addPattern('^(?!.*' . new RangePattern($ranges, negated: false, caseSensitive: $caseSensitive) . ').*$', false);
@@ -189,7 +194,7 @@ trait Contains
      */
     public function containsWordsThatBeginWith(string|int $subject): self
     {
-        return $this->addPattern('(?=.*\b' . $subject . ')', false);
+        return $this->addPattern('(?=.*\b' . $this->resolveSimplePattern($subject) . ')', false);
     }
 
     /**
@@ -199,7 +204,7 @@ trait Contains
      */
     public function containsWordsThatEndWith(string|int $subject): self
     {
-        return $this->addPattern('(?=.*' . $subject . '\b)', false);
+        return $this->addPattern('(?=.*' . $this->resolveSimplePattern($subject) . '\b)', false);
     }
 
     /**

--- a/src/Resolvers/RangePattern.php
+++ b/src/Resolvers/RangePattern.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DamilareKoiki\PhpRegex\Resolvers;
 
-use Exception;
+use LogicException;
 use Stringable;
 
 final readonly class RangePattern implements Stringable
@@ -34,11 +34,11 @@ final readonly class RangePattern implements Stringable
 
         foreach ($this->ranges as $subject1 => $subject2) {
             if (ctype_alpha((string) $subject1) && !ctype_alpha((string) $subject2)) {
-                throw new Exception("Range end '$subject2' must be a letter because range start '$subject1' is a letter.");
+                throw new LogicException("Range end '$subject2' must be a letter because range start '$subject1' is a letter.");
             }
 
             if (ctype_digit((string) $subject1) && !ctype_digit((string) $subject2)) {
-                throw new Exception("Range end '$subject2' must be a digit because range start '$subject1' is a digit.");
+                throw new LogicException("Range end '$subject2' must be a digit because range start '$subject1' is a digit.");
             }
 
             if (!$this->caseSensitive) {

--- a/tests/Unit/ContainsTest.php
+++ b/tests/Unit/ContainsTest.php
@@ -12,6 +12,13 @@ test('contains method vs then method', function (): void {
     expect($consuming->count('applefruit apple pie appleg'))->toBe(2);
 });
 
+test('contains method works well with empty string', function (): void {
+    $regex = Regex::build()->contains('');
+    expect($regex->getPattern())->toBe('(?=.*)');
+    expect($regex->matches('apple'))->toBeTrue()
+        ->and($regex->matches(''))->toBeTrue();
+});
+
 test('doesntContain method works', function (): void {
     $regex = Regex::build(true)->doesntContain('apple');
     expect($regex->getPattern())->toBe('^(?!.*apple).*$');
@@ -19,13 +26,9 @@ test('doesntContain method works', function (): void {
         ->and($regex->matches('sweet apple'))->toBeFalse();
     expect($regex->count('sweet banana'))->toBe(1);
     expect($regex->replace('sweet banana', 'X'))->toBe('X');
-});
 
-test('doesntContain methods ignore empty parameters', function (): void {
-    expect(Regex::build()->doesntContain('')->isEmpty())->toBeTrue();
-    expect(Regex::build()->doesntContainAnyOf([])->isEmpty())->toBeTrue();
-    expect(Regex::build()->doesntContainAnyOf('')->isEmpty())->toBeTrue();
-    expect(Regex::build()->doesntContainBetween([])->isEmpty())->toBeTrue();
+    expect(Regex::build()->doesntContain('')->matches('sweet banana'))->toBeFalse()
+        ->and(Regex::build()->doesntContain('')->matches(''))->toBeFalse();
 });
 
 test('containsAnyOf method works with array', function (): void {
@@ -41,6 +44,9 @@ test('containsAnyOf method works with string', function (): void {
     expect($regex->getPattern())->toBe('(?=.*[abc])');
     expect($regex->matches('apple'))->toBeTrue()
         ->and($regex->matches('dog'))->toBeFalse();
+
+    expect(Regex::build()->containsAnyOf('')->matches('xyz'))->toBeTrue()
+        ->and(Regex::build()->containsAnyOf('')->matches(''))->toBeTrue();
 });
 
 test('doesntContainAnyOf method works with array', function (): void {
@@ -55,6 +61,19 @@ test('doesntContainAnyOf method works with string', function (): void {
     expect($regex->getPattern())->toBe('^[^abc]*$');
     expect($regex->matches('xyz'))->toBeTrue()
         ->and($regex->matches('apple'))->toBeFalse();
+
+    expect(Regex::build()->doesntContainAnyOf('')->matches('xyz'))->toBeFalse()
+        ->and(Regex::build()->doesntContainAnyOf('')->matches(''))->toBeFalse();
+});
+
+test('containsAnyOf method throws exception for empty array', function (): void {
+    expect(fn (): Regex => Regex::build()->containsAnyOf([]))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('doesntContainAnyOf method throws exception for empty array', function (): void {
+    expect(fn (): Regex => Regex::build()->doesntContainAnyOf([]))
+        ->toThrow(InvalidArgumentException::class);
 });
 
 test('digit methods work', function (): void {
@@ -79,6 +98,7 @@ test('digit methods work', function (): void {
     expect(Regex::build()->doesntContainOnlyDigits()->getPattern())->toBe('^$|^(?!\d+$).+');
     expect(Regex::build()->doesntContainOnlyDigits()->matches('123a45'))->toBeTrue()
         ->and(Regex::build()->doesntContainOnlyDigits()->matches('12345'))->toBeFalse()
+        ->and(Regex::build()->doesntContainOnlyDigits()->matches('aaa'))->toBeTrue()
         ->and(Regex::build()->doesntContainOnlyDigits()->matches(''))->toBeTrue();
     expect(Regex::build()->doesntContainOnlyDigits()->count('123a45'))->toBe(1);
     expect(Regex::build()->doesntContainOnlyDigits()->replace('123a45', 'X'))->toBe('X');
@@ -111,6 +131,14 @@ test('containsBetween throws exception for mismatched range types', function ():
         ->toThrow(Exception::class, "Range end 'a' must be a digit because range start '1' is a digit.");
 });
 
+test('containsBetween throws exception for empty array', function (): void {
+    expect(fn (): Regex => Regex::build()->containsBetween([]))->toThrow(InvalidArgumentException::class);
+});
+
+test('doesntContainBetween method throws exception for empty array', function (): void {
+    expect(fn (): Regex => Regex::build()->doesntContainBetween([]))->toThrow(InvalidArgumentException::class);
+});
+
 test('alphanumeric methods work', function (): void {
     expect(Regex::build()->containsAlphaNumeric()->getPattern())->toBe('(?=.*[A-Za-z0-9])');
     expect(Regex::build()->containsAlphaNumeric()->matches('!@#a'))->toBeTrue()
@@ -137,11 +165,15 @@ test('alphanumeric methods work', function (): void {
 test('word boundary methods work', function (): void {
     expect(Regex::build()->containsWordsThatBeginWith('start')->getPattern())->toBe('(?=.*\bstart)');
     expect(Regex::build()->containsWordsThatBeginWith('start')->matches('the start event'))->toBeTrue()
-        ->and(Regex::build()->containsWordsThatBeginWith('start')->matches('restarting'))->toBeFalse();
+        ->and(Regex::build()->containsWordsThatBeginWith('start')->matches('restarting'))->toBeFalse()
+        ->and(Regex::build()->containsWordsThatBeginWith('a.b')->matches('a.b test'))->toBeTrue()
+        ->and(Regex::build()->containsWordsThatBeginWith('a.b')->matches('aXb test'))->toBeFalse();
 
     expect(Regex::build()->containsWordsThatEndWith('end')->getPattern())->toBe('(?=.*end\b)');
     expect(Regex::build()->containsWordsThatEndWith('end')->matches('the weekend'))->toBeTrue()
-        ->and(Regex::build()->containsWordsThatEndWith('end')->matches('ending soon'))->toBeFalse();
+        ->and(Regex::build()->containsWordsThatEndWith('end')->matches('ending soon'))->toBeFalse()
+        ->and(Regex::build()->containsWordsThatEndWith('a.b')->matches('test a.b'))->toBeTrue()
+        ->and(Regex::build()->containsWordsThatEndWith('a.b')->matches('test aXb'))->toBeFalse();
 });
 
 test('letter and whitespace methods work', function (): void {

--- a/tests/Unit/ContainsTest.php
+++ b/tests/Unit/ContainsTest.php
@@ -21,6 +21,13 @@ test('doesntContain method works', function (): void {
     expect($regex->replace('sweet banana', 'X'))->toBe('X');
 });
 
+test('doesntContain methods ignore empty parameters', function (): void {
+    expect(Regex::build()->doesntContain('')->isEmpty())->toBeTrue();
+    expect(Regex::build()->doesntContainAnyOf([])->isEmpty())->toBeTrue();
+    expect(Regex::build()->doesntContainAnyOf('')->isEmpty())->toBeTrue();
+    expect(Regex::build()->doesntContainBetween([])->isEmpty())->toBeTrue();
+});
+
 test('containsAnyOf method works with array', function (): void {
     $regex = Regex::build()->containsAnyOf(['apple', 'banana']);
     expect($regex->getPattern())->toBe('(?=.*(apple|banana))');
@@ -55,11 +62,12 @@ test('digit methods work', function (): void {
     expect(Regex::build()->containsDigit()->matches('abc1def'))->toBeTrue()
         ->and(Regex::build()->containsDigit()->matches('abcdef'))->toBeFalse();
 
-    expect(Regex::build()->doesntContainDigit()->getPattern())->toBe('^(?!.*\d).+$');
+    expect(Regex::build()->doesntContainDigit()->getPattern())->toBe('^(?!.*\d).*$');
     expect(Regex::build()->doesntContainDigit()->matches('abcdef'))->toBeTrue()
         ->and(Regex::build()->doesntContainDigit()->matches('abc1def'))->toBeFalse()
         ->and(Regex::build()->doesntContainDigit()->matches('1'))->toBeFalse()
-        ->and(Regex::build()->doesntContainDigit()->matches(' 1'))->toBeFalse();
+        ->and(Regex::build()->doesntContainDigit()->matches(' 1'))->toBeFalse()
+        ->and(Regex::build()->doesntContainDigit()->matches(''))->toBeTrue();
 
 
     expect(Regex::build()->containsOnlyDigits()->getPattern())->toBe('^\d+$');
@@ -68,9 +76,10 @@ test('digit methods work', function (): void {
     expect(Regex::build()->containsOnlyDigits()->count('12345'))->toBe(1);
     expect(Regex::build()->containsOnlyDigits()->replace('12345', 'X'))->toBe('X');
 
-    expect(Regex::build()->doesntContainOnlyDigits()->getPattern())->toBe('^(?!\d+$).+');
+    expect(Regex::build()->doesntContainOnlyDigits()->getPattern())->toBe('^$|^(?!\d+$).+');
     expect(Regex::build()->doesntContainOnlyDigits()->matches('123a45'))->toBeTrue()
-        ->and(Regex::build()->doesntContainOnlyDigits()->matches('12345'))->toBeFalse();
+        ->and(Regex::build()->doesntContainOnlyDigits()->matches('12345'))->toBeFalse()
+        ->and(Regex::build()->doesntContainOnlyDigits()->matches(''))->toBeTrue();
     expect(Regex::build()->doesntContainOnlyDigits()->count('123a45'))->toBe(1);
     expect(Regex::build()->doesntContainOnlyDigits()->replace('123a45', 'X'))->toBe('X');
 
@@ -88,9 +97,10 @@ test('containsBetween and doesntContainBetween methods work', function (): void 
     expect(Regex::build()->containsBetween(['a' => 'z', '0' => '9'])->matches('hello123'))->toBeTrue()
         ->and(Regex::build()->containsBetween(['a' => 'z', '0' => '9'])->matches('!@#$%'))->toBeFalse();
 
-    expect(Regex::build()->doesntContainBetween(['0' => '9'])->getPattern())->toBe('^(?!.*[0-9]).+$');
+    expect(Regex::build()->doesntContainBetween(['0' => '9'])->getPattern())->toBe('^(?!.*[0-9]).*$');
     expect(Regex::build()->doesntContainBetween(['0' => '5'])->matches('hello6'))->toBeTrue()
-        ->and(Regex::build()->doesntContainBetween(['0' => '9'])->matches('hello123'))->toBeFalse();
+        ->and(Regex::build()->doesntContainBetween(['0' => '9'])->matches('hello123'))->toBeFalse()
+        ->and(Regex::build()->doesntContainBetween(['0' => '9'])->matches(''))->toBeTrue();
 });
 
 test('containsBetween throws exception for mismatched range types', function (): void {
@@ -116,9 +126,10 @@ test('alphanumeric methods work', function (): void {
     expect(Regex::build()->containsOnlyAlphaNumeric()->count('abc123'))->toBe(1);
     expect(Regex::build()->containsOnlyAlphaNumeric()->replace('abc123', 'X'))->toBe('X');
 
-    expect(Regex::build()->doesntContainOnlyAlphaNumeric()->getPattern())->toBe('[^A-Za-z0-9]');
+    expect(Regex::build()->doesntContainOnlyAlphaNumeric()->getPattern())->toBe('^$|[^A-Za-z0-9]');
     expect(Regex::build()->doesntContainOnlyAlphaNumeric()->matches('abc-123'))->toBeTrue()
-        ->and(Regex::build()->doesntContainOnlyAlphaNumeric()->matches('abc123'))->toBeFalse();
+        ->and(Regex::build()->doesntContainOnlyAlphaNumeric()->matches('abc123'))->toBeFalse()
+        ->and(Regex::build()->doesntContainOnlyAlphaNumeric()->matches(''))->toBeTrue();
     expect(Regex::build()->doesntContainOnlyAlphaNumeric()->count('abc-123'))->toBe(1);
     expect(Regex::build()->doesntContainOnlyAlphaNumeric()->replace('abc-123', 'X'))->toBe('abcX123');
 });
@@ -178,7 +189,7 @@ test('chains various contains and doesnt methods', function (): void {
         ->containsNonWordCharacter()
         ->containsAnything();
     
-    expect($regex->getPattern())->toBe('(?=.*\d)^(?!.*\d).+$(?=.*[a-z])(?=.*[A-Z])(?=.*\s)(?=.*\S)(?=.*\w)(?=.*\W)(?=.*.)');
+    expect($regex->getPattern())->toBe('(?=.*\d)^(?!.*\d).*$(?=.*[a-z])(?=.*[A-Z])(?=.*\s)(?=.*\S)(?=.*\w)(?=.*\W)(?=.*.)');
     
     $regex2 = Regex::build()
         ->containsDigit()


### PR DESCRIPTION
- Fix the return value for empty string when using the `contains*` methods and the `doesntContain*` methods
- Throw exceptions when an empty array is passed to the `contains*` and `doesntContain*` methods
- Change exception thrown in RangePattern class from Exception to LogicException
- Add test cases